### PR TITLE
Only text link

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@ class Notification < ActiveRecord::Base
         num_checked = 0;
 
         doc.xpath('//entry').each do |item|
-            link = item.xpath('link')[1].attr('href')
+            link = item.xpath('link')[2].attr('href')
             title = item.xpath('title')[0].content
 
             # Sometimes publishers will rearrange their content and push out a new article that's
@@ -46,7 +46,7 @@ class Notification < ActiveRecord::Base
             response = client.messages.create({
                 :from => RssToSms.config.from_phone,
                 :to => RssToSms.config.to_phone,
-                :body => notification[:message]
+                :body => notification[:link]
             })
             output += notification[:message]
 


### PR DESCRIPTION
Ever since we've had macOS 10.12 and iOS 10, the rich interface of an interpreted link looks better than a plain text SMS. Obviously this punishes anyone on an Android, but anyone on an Android deserves to be punished. Or actually, who am I to say that Android doesn't unfurl links too? I don't know. I don't care. 

![](https://cloud.githubusercontent.com/assets/1827628/21780674/1e979916-d672-11e6-97d2-d6a3e97e7cd4.png)
_Old_

![](https://cloud.githubusercontent.com/assets/1827628/21780679/227c3e74-d672-11e6-981f-b71a5a80b718.png)
_new_