### PR TITLE
Revert "Only text link"

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -14,7 +14,7 @@ class Notification < ActiveRecord::Base
         num_checked = 0;
 
         doc.xpath('//entry').each do |item|
-            link = item.xpath('link')[2].attr('href')
+            link = item.xpath('link')[1].attr('href')
             title = item.xpath('title')[0].content
 
             # Sometimes publishers will rearrange their content and push out a new article that's
@@ -46,7 +46,7 @@ class Notification < ActiveRecord::Base
             response = client.messages.create({
                 :from => RssToSms.config.from_phone,
                 :to => RssToSms.config.to_phone,
-                :body => notification[:link]
+                :body => notification[:message]
             })
             output += notification[:message]
 


### PR DESCRIPTION
Reverts martynchamberlin/rss-to-sms#1

This doesn't actually work [because](https://www.reddit.com/r/iOSBeta/comments/4zwq6n/discussion_tap_to_load_preview_in_imessage/):

> I think it only the sender sees it as a preview. As a recipient, I've only seen the 'tap to load preview' bubble.

Seriously bummer, but it's true. 