### PR TITLE
Switch to the JSON feed

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,26 +1,35 @@
+require 'net/http'
+require 'json'
+
 class Notification < ActiveRecord::Base
 
-	def generate
+  def generate
 
         require 'open-uri'
         require 'twilio-ruby'
         output = ''
-        link = ''
 
-        doc = Nokogiri::HTML(open(RssToSms.config.rss_url))
+        response = Net::HTTP.get(URI(RssToSms.config.rss_url))
+        feed = JSON.parse(response)
 
         client = Twilio::REST::Client.new RssToSms.config.twilio_account_sid, RssToSms.config.twilio_auth_token
         notifications = Array.new;
         num_checked = 0;
 
-        doc.xpath('//entry').each do |item|
-            link = item.xpath('link')[2].attr('href')
-            title = item.xpath('title')[0].content
+        feed['items'].each do |item|
+
+          # Do this when your guid method changes and you don't want to flood yourself
+          # with notifications for things that you've already sent out. In theory the
+          # hardcoded date on the left corresponds to the timestamp of when you deployed
+          # the updated guid schema.
+          if (DateTime.parse('2017-06-18T18:55:35Z') > DateTime.parse(item['date_published']))
+            break
+          end
 
             # Sometimes publishers will rearrange their content and push out a new article that's
             # underneath a previously published article. When we encounter the most recently sent
             # item, we want to look a couple underneath that to make sure nothing sticky is going on
-            if Notification.exists?(guid: link)
+            if Notification.exists?(guid: item['id'])
                 if num_checked < 2
                     num_checked += 1
                     next
@@ -30,9 +39,9 @@ class Notification < ActiveRecord::Base
             end
 
             # SMS limit is 140 and subtract additional for white space
-            max_title = 140 - link.length - 1
-            message = title[0..max_title] + " " + link
-            notifications << {message: message, link: link}
+            max_title = 140 - item['url'].length - 1
+            message = item['title'][0..max_title] + " " + item['url']
+            notifications << {message: message, link: item['url']}
 
         end
 
@@ -46,7 +55,7 @@ class Notification < ActiveRecord::Base
             response = client.messages.create({
                 :from => RssToSms.config.from_phone,
                 :to => RssToSms.config.to_phone,
-                :body => notification[:link]
+                :body => notification[:message]
             })
             output += notification[:message]
 
@@ -54,5 +63,5 @@ class Notification < ActiveRecord::Base
 
         return output
 
-	end
+  end
 end


### PR DESCRIPTION
I love this because it gets the code away from the Daringfireball-specific RSS feed which was a PITA to parse, and moves us towards a universal JSON standard feed setup. What pushed me over the edge to do this in the first place is because of a domain redirection issue that's come up recently. Here's how I explained it to John: 

> Your atom RSS contains a "shorturl" link for each entry. An example value of this is http://df4.us/q2b. The problem is that the df4.us domain redirects to daringfireball.net and then daringfireball.net, as of a few weeks ago apparently, redirects to the HTTPS version. This HTTPS redirect pays no attention to what is after the TLD. Thus, a link like http://df4.us/q2b resolves to the home page instead of to the original article it's pointing to. This has a debilitating effect on my app that sends me an SMS whenever you post something. Would love to see this fixed.

He hasn't fixed this yet and I've grown impatient, plus I wanted to have a chance to implement a JSON feed listener anyway. 